### PR TITLE
Omitting the resources query parameter from the authentication url

### DIFF
--- a/authHelper.js
+++ b/authHelper.js
@@ -11,7 +11,6 @@ var credentials = {
 
 /**
  * Generate a fully formed uri to use for authentication based on the supplied resource argument
- * @param {string} res the desired resource endpoint uri
  * @return {string} a fully formed uri with which authentcation can be completed
  */
 function getAuthUrl() {

--- a/authHelper.js
+++ b/authHelper.js
@@ -14,10 +14,9 @@ var credentials = {
  * @param {string} res the desired resource endpoint uri
  * @return {string} a fully formed uri with which authentcation can be completed
  */
-function getAuthUrl(res) {
+function getAuthUrl() {
     return credentials.authority + "/oauth2/authorize" +
         "?client_id=" + credentials.client_id +
-        "&resources=" + res +
         "&response_type=code" +
         "&redirect_uri=" + credentials.redirect_uri;
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -47,7 +47,7 @@ router.get('/login', function (req, res, next) {
     });
   }
   else {
-    res.render('login', { auth_url: authHelper.getAuthUrl('https://graph.microsoft.com/') });
+    res.render('login', { auth_url: authHelper.getAuthUrl() });
   }
 });
 


### PR DESCRIPTION
adal-node can handle the access token acquisition - no need to add this extra information.